### PR TITLE
Support Tick data and ask/bid

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ self.cancel(self.buy_order[0])
 
 ## Usage
 
+### Live trading example
+
 ```python
 import backtrader as bt
 from backtradermt5.mt5store import MTraderStore
@@ -110,13 +112,41 @@ start_date = datetime.now() - timedelta(minutes=500)
 
 data = store.getdata(dataname='EURUSD', timeframe=bt.TimeFrame.Ticks,
                      fromdate=start_date) #, useask=True, historical=True)
+                     # the parameter "useask" will request the ask price insetad if the default bid price
 
 cerebro.resampledata(data,
                      timeframe=bt.TimeFrame.Seconds,
                      compression=30
                      )
+
 cerebro.run(stdstats=False)
 cerebro.plot(style='candlestick', volume=False)
+```
+
+### Download CSV data
+
+You can instruct MT5 to download historical data as a CSV file. Files will be saved into the local Metatrader 5 Terminal installation folder:
+
+`[MT5 Terminal]/MQL/Files/Data`
+
+The example below downloads data for the past 6 months as tick data.
+
+```python
+from datetime import datetime, timedelta
+from backtradermql5.mt5store import MTraderStore
+import backtrader as bt
+
+store = MTraderStore(host='192.168.1.20') # Metatrader 5 running on a diffenet host
+
+start_date = datetime.now() - timedelta(months=6)
+
+cerebro = bt.Cerebro()
+data2 = store.getdata(dataname='EURUSD',
+                      timeframe=bt.TimeFrame.Ticks,
+                      fromdate=start_date
+                      )
+
+cerebro.run(stdstats=False)
 ```
 
 ## License
@@ -124,3 +154,7 @@ cerebro.plot(style='candlestick', volume=False)
 This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
 
 This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See `LICENSE` for more information.
+
+```
+
+```

--- a/README.md
+++ b/README.md
@@ -108,10 +108,13 @@ cerebro.setbroker(broker)
 
 start_date = datetime.now() - timedelta(minutes=500)
 
-data = store.getdata(dataname='EURUSD', timeframe=bt.TimeFrame.Minutes,
-                     fromdate=start_date, compression=1) #, historical=True)
+data = store.getdata(dataname='EURUSD', timeframe=bt.TimeFrame.Ticks,
+                     fromdate=start_date) #, useask=True, historical=True)
 
-cerebro.adddata(data)
+cerebro.resampledata(data,
+                     timeframe=bt.TimeFrame.Seconds,
+                     compression=30
+                     )
 cerebro.run(stdstats=False)
 cerebro.plot(style='candlestick', volume=False)
 ```

--- a/backtradermql5/mt5data.py
+++ b/backtradermql5/mt5data.py
@@ -230,8 +230,9 @@ class MTraderData(with_metaclass(MetaMTraderData, DataBase)):
 
     def _load_tick(self, msg):
         time_stamp, _bid, _ask = msg
+        # convert unix timestamp to float for millisecond resolution
         d_time = datetime.utcfromtimestamp(
-            time_stamp)
+            float(time_stamp) / 1000.0)
 
         dt = date2num(d_time)
 

--- a/backtradermql5/mt5data.py
+++ b/backtradermql5/mt5data.py
@@ -254,6 +254,7 @@ class MTraderData(with_metaclass(MetaMTraderData, DataBase)):
         return True
 
     def _load_candle(self, ohlcv):
+        # TODO support bid/ask using spread
         time_stamp, _open, _high, _low, _close, _volume = ohlcv
         d_time = datetime.utcfromtimestamp(
             time_stamp)
@@ -271,12 +272,4 @@ class MTraderData(with_metaclass(MetaMTraderData, DataBase)):
         self.lines.close[0] = _close
         self.lines.volume[0] = _volume
         self.lines.openinterest[0] = 0.0
-        return True
-
-        # Put the prices into the bar
-        tick = float(_ask) if self.p.useask else float(_bid)
-        self.lines.open[0] = tick
-        self.lines.high[0] = tick
-        self.lines.low[0] = tick
-        self.lines.close[0] = tick
         return True

--- a/backtradermql5/mt5store.py
+++ b/backtradermql5/mt5store.py
@@ -295,7 +295,7 @@ class MTraderStore(with_metaclass(MetaSingleton, object)):
         granularity = self._GRANULARITIES.get((frame, compression), None)
         if granularity is None:
             raise ValueError("Metatrader 5 doesn't support frame %s with compression %s" % \
-                             (bt.TimeFrame.getname(frame), compression))
+                             (bt.TimeFrame.getname(frame, compression), compression))
         return granularity
 
     def get_cash(self):

--- a/backtradermql5/mt5store.py
+++ b/backtradermql5/mt5store.py
@@ -198,7 +198,6 @@ class MTraderStore(with_metaclass(MetaSingleton, object)):
     # MTrader supported granularities
     _GRANULARITIES = {
         (bt.TimeFrame.Ticks, 1): 'TICKS',
-        (bt.TimeFrame.Seconds, 10): 'SECONDS',
         (bt.TimeFrame.Minutes, 1): 'M1',
         (bt.TimeFrame.Minutes, 5): 'M5',
         (bt.TimeFrame.Minutes, 15): 'M15',
@@ -233,7 +232,6 @@ class MTraderStore(with_metaclass(MetaSingleton, object)):
         params = {'timeframe': bt.TimeFrame.Days,
                   'compression': 1}
         params.update(kwargs)
-
         cls.getdata_params = params
         return cls.DataCls(*args, **kwargs)
 
@@ -350,13 +348,13 @@ class MTraderStore(with_metaclass(MetaSingleton, object)):
         socket = self.oapi.live_socket()
         while True:
             try:
-                last_candle = socket.recv_json()
+                last_data = socket.recv_json()
                 if self.debug:
-                    print('ZMQ LIVE DATA: ', last_candle)
+                    print('ZMQ LIVE DATA: ', last_data)
             except zmq.ZMQError:
                 raise zmq.NotDone("Live data ERROR")
 
-            self.q_livedata.put(last_candle)
+            self.q_livedata.put(last_data)
 
     def _t_streaming_events(self):
         # create socket connection for the Thread

--- a/backtradermql5/mt5store.py
+++ b/backtradermql5/mt5store.py
@@ -49,12 +49,13 @@ class MTraderAPI:
     # TODO: unify error handling
 
     def __init__(self, *args, **kwargs):
-        self.HOST = kwargs['host'] or 'localhost'
+
+        self.HOST = kwargs['host']
         self.SYS_PORT = 15555       # REP/REQ port
         self.DATA_PORT = 15556      # PUSH/PULL port
         self.LIVE_PORT = 15557      # PUSH/PULL port
         self.EVENTS_PORT = 15558    # PUSH/PULL port
-        self.debug = kwargs['debug'] or False
+        self.debug = kwargs['debug']
 
         # ZeroMQ timeout in seconds
         sys_timeout = 1
@@ -187,7 +188,10 @@ class MTraderStore(with_metaclass(MetaSingleton, object)):
     BrokerCls = None  # broker class will autoregister
     DataCls = None  # data class will auto register
 
-    params = ()
+    params = (
+        ('host', 'localhost'),
+        ('debug', False)
+    )
 
     _DTEPOCH = datetime(1970, 1, 1)
 
@@ -229,6 +233,7 @@ class MTraderStore(with_metaclass(MetaSingleton, object)):
         params = {'timeframe': bt.TimeFrame.Days,
                   'compression': 1}
         params.update(kwargs)
+
         cls.getdata_params = params
         return cls.DataCls(*args, **kwargs)
 
@@ -250,6 +255,7 @@ class MTraderStore(with_metaclass(MetaSingleton, object)):
         self._ordersrev = collections.OrderedDict()  # map oid to order.ref
         self._orders_type = dict()  # keeps order types
 
+        kwargs.update({"host": self.params.host, "debug": self.params.debug})
         self.oapi = MTraderAPI(*args, **kwargs)
 
         self._cash = 0.0
@@ -259,7 +265,7 @@ class MTraderStore(with_metaclass(MetaSingleton, object)):
 
         self._cancel_flag = False
 
-        self.debug = kwargs['debug'] or False
+        self.debug = self.params.debug
 
     def start(self, data=None, broker=None):
         # Datas require some processing to kickstart data reception

--- a/changelog.md
+++ b/changelog.md
@@ -1,0 +1,7 @@
+### 11th January 2020
+
+- add support for multiple datastreams in parallel for any combination of symbols and timeframes
+- add support for tick data
+- add support for ask price
+- add support for direct download as CSV files
+- add parameter options for `host`, `debug` and `datatimeout`


### PR DESCRIPTION
Add support for tick data and ask/bid fields.
I updated the example code in the README to show it's usage.

Below are the contents of the changelog:
- add support for multiple datastreams in parallel for any combination of symbols and timeframes
- add support for tick data
- add support for ask price
- add support for direct download as CSV files
- add parameter options for `host`, `debug` and `datatimeout`



The new functionality requires changes from this PR: https://github.com/khramkov/MQL5-JSON-API/pull/6 
